### PR TITLE
Remove stray table cell from "2012-11-15-redis-performance..."

### DIFF
--- a/_posts/2012-11-15-redis-performance-does-key-length-matter.html
+++ b/_posts/2012-11-15-redis-performance-does-key-length-matter.html
@@ -82,7 +82,6 @@ redis = require "redis"</p>
 <td>1235</td>
 <td>1216</td>
 <td>1259</td>
-<td></td>
 </tr>
 <tr style="border:1px solid black;">
 <td>100</td>


### PR DESCRIPTION
On, http://adamnengland.com/2012/11/15/redis-performance-does-key-length-matter/ , the empty cell gives this row one more than the rest.

Before:
![before](https://i.imgur.com/JwoRxlW.png)

After:
![after](https://i.imgur.com/qypmnr4.png)